### PR TITLE
Fix to logging error: WARNING arguments left: 1

### DIFF
--- a/src/main/g8/library/core/src/main/scala/$organisation_domain$/$organisation$/$name$/core/application/ApplicationBootstrapping.scala
+++ b/src/main/g8/library/core/src/main/scala/$organisation_domain$/$organisation$/$name$/core/application/ApplicationBootstrapping.scala
@@ -104,8 +104,8 @@ trait ApplicationBootstrapping {
               case Success(_) =>
                 log.info(s"Application \$applicationName started")
               case Failure(exn) =>
-                log.error(
-                  s"Application \$applicationName shutting down due to an error: \$exn"
+                log.error(exn,
+                  s"Application \$applicationName shutting down due to an error"
                 )
                 systemExitAllowed.set(true)
                 sys.exit(1)
@@ -123,15 +123,15 @@ trait ApplicationBootstrapping {
         def uncaughtException(thread: Thread, exn: Throwable): Unit =
           exn match {
             case NonFatal(_) =>
-              log.error(
+              log.error(exn,
                 "BUG: non-fatal exception should have been handled by " +
-                  s"application \$applicationName! \$exn"
+                  s"application \$applicationName!"
               )
               systemExitAllowed.set(true)
               sys.exit(2)
             case _: Throwable =>
-              log.error(
-                s"Fatal exception thrown by application \$applicationName: \$exn"
+              log.error(exn,
+                s"Fatal exception thrown by application \$applicationName"
               )
               systemExitAllowed.set(true)
               sys.exit(3)

--- a/src/main/g8/library/core/src/main/scala/$organisation_domain$/$organisation$/$name$/core/config/ConfigurationFailure.scala
+++ b/src/main/g8/library/core/src/main/scala/$organisation_domain$/$organisation$/$name$/core/config/ConfigurationFailure.scala
@@ -11,10 +11,4 @@ import cats.data.NonEmptyList
   */
 final case class ConfigurationFailure(
   errors: NonEmptyList[ValueError]
-) extends Exception {
-
-  /** @see java.lang.Exception */
-  override def toString: String = {
-    s"ConfigurationFailure(\${errors.toList.mkString(",")})"
-  }
-}
+) extends Exception(errors.toList.mkString(", "))


### PR DESCRIPTION
Akka Logging throws an error ("WARNING arguments left: 1" ) when it doesn't find placeholders, unlike other logging frameworks.
- [x] Ready for review
- [x] Ready to merge