### PR TITLE
Add .gitignore file to generated project.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ project/boot/
 project/plugins/project/
 
 # Scala-IDE specific
+.idea
 .scala_dependencies
 .worksheet

--- a/src/main/g8/.gitignore
+++ b/src/main/g8/.gitignore
@@ -1,0 +1,6 @@
+.idea/
+library/core/target/
+mains/server/target/
+project/project/target/
+project/target/
+target/

--- a/src/main/g8/Jenkinsfile
+++ b/src/main/g8/Jenkinsfile
@@ -11,8 +11,8 @@ pipeline {
   }
 
   stages {
-    steps {
-      stage('Environment') {
+    stage('Environment') {
+      steps {
         ansiColor('xterm') {
           script {
             sh "sbt checkExternalBuildTools"

--- a/src/main/g8/library/core/src/main/scala/$organisation_domain$/$organisation$/$name$/core/application/ApplicationBootstrapping.scala
+++ b/src/main/g8/library/core/src/main/scala/$organisation_domain$/$organisation$/$name$/core/application/ApplicationBootstrapping.scala
@@ -104,7 +104,8 @@ trait ApplicationBootstrapping {
               case Success(_) =>
                 log.info(s"Application \$applicationName started")
               case Failure(exn) =>
-                log.error(exn,
+                log.error(
+                  exn,
                   s"Application \$applicationName shutting down due to an error"
                 )
                 systemExitAllowed.set(true)
@@ -123,14 +124,16 @@ trait ApplicationBootstrapping {
         def uncaughtException(thread: Thread, exn: Throwable): Unit =
           exn match {
             case NonFatal(_) =>
-              log.error(exn,
+              log.error(
+                exn,
                 "BUG: non-fatal exception should have been handled by " +
                   s"application \$applicationName!"
               )
               systemExitAllowed.set(true)
               sys.exit(2)
             case _: Throwable =>
-              log.error(exn,
+              log.error(
+                exn,
                 s"Fatal exception thrown by application \$applicationName"
               )
               systemExitAllowed.set(true)

--- a/src/main/g8/library/core/src/main/scala/$organisation_domain$/$organisation$/$name$/core/application/StartUpLogging.scala
+++ b/src/main/g8/library/core/src/main/scala/$organisation_domain$/$organisation$/$name$/core/application/StartUpLogging.scala
@@ -73,7 +73,9 @@ private object StartUpLogging {
   )(implicit log: LoggingAdapter): Unit = {
     val configData = config.entrySet().asScala.toList.sortBy(_.getKey)
     for (entry <- configData) {
-      log.info(s"configuration: \${entry.getKey}=\${entry.getValue.unwrapped()}")
+      log.info(
+        s"configuration: \${entry.getKey}=\${entry.getValue.unwrapped()}"
+      )
     }
   }
 


### PR DESCRIPTION
Currently the when the generated project is built it will generate a number of directories which should be ignored. As this template will be used as part of the initial commit for many projects, this may lead to things being committed which should not be. This PR adds a .gitignore file to the template directory.